### PR TITLE
Add solidity syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Added a special file to allow github code viewers to highlight Solidity syntax in the `sol`-files 